### PR TITLE
docs: add project agent skills

### DIFF
--- a/.agents/skills/deployerphp-bats-testing/SKILL.md
+++ b/.agents/skills/deployerphp-bats-testing/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: deployerphp-bats-testing
+description: Design and update DeployerPHP BATS integration tests across VM and cloud suites, including non-interactive command execution, inventory isolation, run-suffix resource isolation, cleanup contracts, and helper usage. Use when editing tests/bats/*, bats.sh, or cloud janitor flows.
+---
+
+# BATS Testing
+
+Use this skill for BATS architecture, test updates, and runner/cleanup flows.
+
+## Protocol
+
+1. Read `references/bats-rules.md` before changing BATS files.
+2. Keep tests on success-path non-interactive flows and pass all required CLI
+   options.
+3. Preserve suite isolation and cloud resource naming/cleanup contracts.
+4. Use documented helpers and setup/teardown guard patterns.
+
+## References
+
+- `references/bats-rules.md` - full BATS rules and examples migrated from
+  `AGENTS.md`.

--- a/.agents/skills/deployerphp-bats-testing/references/bats-rules.md
+++ b/.agents/skills/deployerphp-bats-testing/references/bats-rules.md
@@ -1,0 +1,458 @@
+# BATS Rules
+
+Functional CLI testing using BATS (Bash Automated Testing System). Tests are divided into two categories: VM tests (using Lima VMs via SSH) and Cloud tests (against real cloud provider APIs).
+
+> **IMPORTANT**
+>
+> - SUCCESS paths only - no failure-path tests (those belong in PHP unit tests)
+> - BATS must only test NON-INTERACTIVE command paths (Laravel Prompts requires TTY)
+> - Always provide ALL CLI options to skip prompts
+
+## Context
+
+### Testing Philosophy
+
+BATS tests are a "test drive around the track" - proving the system works end-to-end with valid inputs.
+
+**Success paths only:**
+
+- Test commands complete successfully with valid inputs
+- Verify side effects (files created, services running, users exist)
+
+**Rationale:**
+
+- Long-running commands (e.g., `server:install`) take 5+ minutes per distro
+- Timeout-based tests are inherently flaky
+- Integration tests prove the system works; unit tests prove edge cases fail correctly
+
+### Structure
+
+```text
+bats.sh                      # Test runner (interactive menu + CI mode)
+tests/bats/
+├── vm.bats                  # VM/server command tests (Lima required)
+├── cloud-aws.bats           # AWS provisioning tests (no VM)
+├── cloud-do.bats            # DigitalOcean provisioning tests (no VM)
+├── lima/
+│   └── ubuntu24.yaml        # Ubuntu 24.04 VM config
+├── lib/
+│   ├── helpers.bash         # Assertions and test utilities
+│   ├── cloud-helpers.bash   # Cloud provider credential checks and cleanup
+│   ├── lima-core.bash       # Shared Lima functions (used by bats.sh and lima.bash)
+│   ├── lima.bash            # Lima VM lifecycle management (BATS context)
+│   └── inventory.bash       # Test inventory manipulation
+└── fixtures/
+    ├── keys/                # SSH keys for test servers
+    └── inventory/           # Test inventory files
+```
+
+### Test Categories
+
+| Category | Tests                             | Requirements             | Trigger               |
+| -------- | --------------------------------- | ------------------------ | --------------------- |
+| VM       | `vm.bats`                         | Lima VMs, SSH access     | `./bats.sh run vm`    |
+| Cloud    | `cloud-aws.bats`, `cloud-do.bats` | Provider API credentials | `./bats.sh run cloud` |
+
+**VM Tests** — server management and service installations:
+
+- Server lifecycle: add, delete, info, firewall, logs, run, ssh
+- Service installs: mariadb, postgresql, redis, memcached
+- Runs against Lima VMs via SSH
+- Require Lima installed locally
+
+**Cloud Tests** — cloud provisioning and site lifecycle:
+
+- Cloud provider integration: provision, DNS, key management
+- Site lifecycle: create, shared:{push,list,pull}, deploy, dns:check, https
+- HTTP verification of deployed sites
+- Runs against real cloud APIs (AWS, DigitalOcean, Cloudflare)
+- Fail with diagnostics if credentials not configured (no silent skips)
+
+### Per-Suite Inventory Isolation
+
+Each BATS test file gets its own inventory file (e.g., `cloud-aws.yml`, `vm-ubuntu24.yml`), created automatically by `helpers.bash`. This prevents test suites from interfering with each other and enables parallel execution. VM tests append the distro via `BATS_INVENTORY_SUFFIX` (set by `bats.sh`). Both VM and cloud `teardown_file()` clean up their inventory with `rm -f "$TEST_INVENTORY"`.
+
+### VM Testing
+
+VM tests run against Ubuntu. Each distro has its own VM and SSH port:
+
+| Distro   | Port | VM Instance            |
+| -------- | ---- | ---------------------- |
+| ubuntu24 | 2224 | deployer-test-ubuntu24 |
+
+### Run-Scoped Resource Isolation (Cloud)
+
+Cloud tests use `BATS_RUN_SUFFIX` to make all resource names unique per run, enabling safe parallel CI execution.
+
+**Source:** Computed once in `bats.sh` before invoking BATS. CI: last 6 chars of `BATS_RUN_SUFFIX` env var (set from `github.run_id`). Local: `bats.sh` PID (`$$`). `cloud-helpers.bash` inherits the value; it does not recompute it.
+
+**Run-scoped variables (cloud-helpers.bash):**
+
+| Variable               | Pattern                      | Example                    |
+| ---------------------- | ---------------------------- | -------------------------- |
+| `AWS_TEST_SERVER_NAME` | `deployer-bats-aws-{SUFFIX}` | `deployer-bats-aws-123456` |
+| `AWS_TEST_KEY_NAME`    | `deployer-bats-aws-{SUFFIX}` | `deployer-bats-aws-123456` |
+| `AWS_TEST_DNS_ROOT`    | `r{SUFFIX}`                  | `r123456`                  |
+| `AWS_TEST_SITE_DOMAIN` | `r{SUFFIX}.{zone}`           | `r123456.deployeraws.eu`   |
+| `DO_TEST_SERVER_NAME`  | `deployer-bats-do-{SUFFIX}`  | `deployer-bats-do-123456`  |
+| `DO_TEST_KEY_NAME`     | `deployer-bats-do-{SUFFIX}`  | `deployer-bats-do-123456`  |
+| `DO_TEST_DNS_ROOT`     | `r{SUFFIX}`                  | `r123456`                  |
+| `DO_TEST_SITE_DOMAIN`  | `r{SUFFIX}.{zone}`           | `r123456.deployerdo.eu`    |
+| `CF_TEST_DNS_ROOT`     | `r{SUFFIX}`                  | `r123456`                  |
+
+### Entry Points
+
+**`bats.sh`** is the test runner script at the project root. It handles VM lifecycle (Lima), interactive menus, CI mode, and resource isolation. All BATS test execution flows through this script.
+
+**Composer scripts** (`composer.json`) provide convenient aliases:
+
+| Composer Script       | Equivalent        | Description                  |
+| --------------------- | ----------------- | ---------------------------- |
+| `composer bats`       | `./bats.sh run`   | Run tests (interactive menu) |
+| `composer bats:start` | `./bats.sh start` | Start Lima VMs               |
+| `composer bats:stop`  | `./bats.sh stop`  | Stop Lima VMs                |
+
+### Commands
+
+```bash
+# Interactive mode (shows category menu)
+./bats.sh                    # Select: cloud or vm -> select target
+
+# Direct category (prompts for target)
+./bats.sh run cloud          # Prompts for provider: all, aws, do
+./bats.sh run vm             # Prompts for distro: all, ubuntu24
+
+# Direct test file
+./bats.sh run cloud-aws      # Run AWS cloud tests directly
+./bats.sh run cloud-do       # Run DigitalOcean cloud tests directly
+
+# CI mode (non-interactive, requires CI=true)
+CI=true ./bats.sh ci cloud aws      # Run AWS cloud tests
+CI=true ./bats.sh ci cloud do       # Run DO cloud tests
+CI=true ./bats.sh ci cloud all      # Run all cloud tests
+CI=true ./bats.sh ci vm ubuntu24    # Run VM tests on ubuntu24
+
+# VM management
+./bats.sh start [distro]     # Start VMs (all if no distro)
+./bats.sh stop [distro]      # Stop VMs
+./bats.sh reset [distro]     # Factory reset VMs (delete + recreate)
+./bats.sh clean [distro]     # Clean VM state without restart
+./bats.sh ssh <distro>       # SSH into a test VM
+
+# Debug mode
+BATS_DEBUG=1 ./bats.sh run   # Enable verbose debug output
+```
+
+### Running Tests
+
+**Always use `bats.sh` as the entry point.** It manages VM lifecycle, sets env vars, and ensures isolation.
+
+**Full suite (recommended for CI and final validation):**
+
+```bash
+# Start VM, run all VM tests on a distro, stop VM
+CI=true ./bats.sh ci vm ubuntu24
+
+# Interactive: prompts for category and target
+./bats.sh run vm
+```
+
+**Single test filtering (for quick iteration during development):**
+
+`bats.sh` does not support `--filter`. To run a single test, start the VM separately, then invoke `bats` directly with the required env vars:
+
+```bash
+# 1. Start the VM (only needed once)
+./bats.sh start ubuntu24
+
+# 2. Run a single test by name (BATS_DISTRO and BATS_INVENTORY_SUFFIX are required)
+BATS_DISTRO=ubuntu24 BATS_INVENTORY_SUFFIX=ubuntu24 \
+  bats --print-output-on-failure --filter "mysql:install saves credentials" tests/bats/vm.bats
+
+# 3. Stop the VM when done
+./bats.sh stop ubuntu24
+```
+
+| Env Var                 | Purpose                                  | Required       |
+| ----------------------- | ---------------------------------------- | -------------- |
+| `BATS_DISTRO`           | Selects SSH port from `DISTRO_PORTS` map | Yes (VM tests) |
+| `BATS_INVENTORY_SUFFIX` | Isolates inventory file per distro       | Yes (VM tests) |
+| `BATS_DEBUG=1`          | Enables `debug_output()` verbose logging | No             |
+
+**Cloud tests (no VM needed):**
+
+```bash
+./bats.sh run cloud-aws       # Run AWS cloud tests
+./bats.sh run cloud-do        # Run DO cloud tests
+
+# Filter a single cloud test
+bats --print-output-on-failure --filter "aws:key:add" tests/bats/cloud-aws.bats
+```
+
+### Available Helpers
+
+**Assertions (helpers.bash):**
+
+- `assert_success_output` - Output contains `✓`
+- `assert_error_output` - Output contains `✗`
+- `assert_info_output` - Output contains `ℹ`
+- `assert_warning_output` - Output contains `!`
+- `assert_output_contains "text"` - Output contains string
+- `assert_output_not_contains "text"` - Output does NOT contain string
+- `assert_command_replay "cmd"` - Output contains command replay
+- `assert_success` - Exit status is 0
+- `assert_failure` - Exit status is non-zero
+
+**Execution (helpers.bash):**
+
+- `run_deployer cmd --opt` - Run deployer with test inventory and `--no-ansi`
+- `run_deployer_success cmd` - Run and assert success
+- `run_deployer_failure cmd` - Run and assert failure
+- `debug_output` - Print output when BATS_DEBUG=1
+- `debug "message"` - Print debug message when BATS_DEBUG=1
+
+**Inventory (inventory.bash):**
+
+- `reset_inventory` - Empty inventory
+- `add_test_server [name]` - Add test server to inventory
+- `inventory_has_server "name"` - Check server exists
+- `inventory_has_site "domain"` - Check site exists
+
+**SSH (helpers.bash):**
+
+- `ssh_exec "command"` - Execute on test VM
+- `assert_remote_file_exists "/path"` - Check remote file
+- `assert_remote_dir_exists "/path"` - Check remote directory
+- `assert_remote_file_contains "/path" "text"` - Check file content
+
+**Lima (lima.bash):**
+
+- `lima_clean` - Clean VM state via SSH
+- `lima_is_running` - Check if VM is running
+- `lima_logs [lines]` - Get VM system logs
+
+**Fail-Fast (cloud-helpers.bash):**
+
+- `cloud_mark_failed` - Write sentinel file when test fails (call from `teardown()`)
+- `cloud_check_failed` - Skip if a previous test failed (call from `setup()`)
+
+**Cloud Credentials (cloud-helpers.bash):**
+
+- `aws_credentials_available` - Check AWS env vars set
+- `do_credentials_available` - Check DO API token set
+- `cf_credentials_available` - Check Cloudflare API token set
+- `aws_provision_config_available` - Check full AWS config for provisioning
+- `do_provision_config_available` - Check full DO config for provisioning
+- `require_aws_credentials` - Fail with diagnostics if AWS credentials missing
+- `require_aws_provision_config` - Fail with diagnostics if AWS provisioning config incomplete
+- `require_cf_credentials` - Fail with diagnostics if Cloudflare credentials missing
+- `require_do_credentials` - Fail with diagnostics if DO credentials missing
+- `require_do_provision_config` - Fail with diagnostics if DO provisioning config incomplete
+
+**Cloud Cleanup (cloud-helpers.bash):**
+
+- `aws_cleanup_test_key` - Remove AWS test SSH key
+- `aws_cleanup_test_server` - Remove AWS test server and cloud instance
+- `aws_cleanup_test_dns` - Remove Route53 run-scoped A records (CLI)
+- `aws_cleanup_test_dns_raw` - Remove Route53 run-scoped A records (raw AWS CLI safety net)
+- `aws_cleanup_all` - Full AWS cleanup (server → DNS → DNS raw → site → key)
+- `do_cleanup_test_key` - Remove DO test SSH key
+- `do_cleanup_test_server` - Remove DO test server and droplet
+- `do_cleanup_test_dns` - Remove DO DNS run-scoped A records (CLI)
+- `do_cleanup_test_dns_raw` - Remove DO DNS run-scoped A records (raw DO API safety net)
+- `do_cleanup_all` - Full DO cleanup (server → DNS → DNS raw → site → key)
+- `cf_cleanup_test_dns` - Remove Cloudflare run-scoped A records (CLI)
+- `cf_cleanup_test_dns_raw` - Remove Cloudflare run-scoped A records (raw CF API safety net)
+- `cf_cleanup_all` - Full CF cleanup (DNS → DNS raw)
+- `do_find_key_id_by_name "name"` - Find DO key ID by name
+- `do_extract_key_id_from_output "output"` - Extract key ID from command output
+
+**Shared Cloud Helpers (cloud-helpers.bash):**
+
+- `get_server_ip "server-name"` - Get server IP from inventory
+- `cleanup_test_site "domain"` - Remove test site from inventory
+- `wait_for_http "domain" ["content"] [timeout] ["ip"]` - Wait for HTTP response
+
+### Adding a New Distro
+
+1. Create `lima/{distro}.yaml` (copy existing, update image URLs and port)
+2. Add to `DISTRO_PORTS` and `DISTROS` in `bats.sh`
+3. Add to `DISTRO_PORTS` in `lib/helpers.bash`
+
+### Dependencies
+
+```bash
+# VM tests require Lima
+brew install bats-core lima jq
+
+# Cloud tests only need BATS
+brew install bats-core jq
+```
+
+## Examples
+
+### Example: VM Test Template
+
+```bash
+#!/usr/bin/env bats
+
+load 'lib/helpers'
+load 'lib/lima'
+load 'lib/inventory'
+
+# ----
+# Setup/Teardown
+# ----
+
+teardown_file() {
+    rm -f "$TEST_INVENTORY"
+}
+
+setup() {
+    reset_inventory
+}
+
+# ----
+# command:name
+# ----
+
+@test "command:name does something" {
+    add_test_server
+
+    run_deployer command:name --option=value
+
+    debug_output
+
+    [ "$status" -eq 0 ]
+    assert_success_output
+    assert_output_contains "Expected text"
+    assert_command_replay "command:name"
+}
+```
+
+### Example: Cloud Test Template
+
+```bash
+#!/usr/bin/env bats
+
+load 'lib/helpers'
+load 'lib/cloud-helpers'
+
+# ----
+# Setup/Teardown
+# ----
+
+setup_file() {
+    require_aws_credentials
+    require_cf_credentials
+    aws_cleanup_all
+}
+
+teardown_file() {
+    # Use raw *_available() - cleanup must always attempt
+    if ! aws_credentials_available; then
+        return 0
+    fi
+    aws_cleanup_all
+    rm -f "$TEST_INVENTORY"
+}
+
+setup() {
+    cloud_check_failed
+    require_aws_credentials
+}
+
+teardown() {
+    cloud_mark_failed
+}
+
+# ----
+# aws:key:add
+# ----
+
+@test "aws:key:add uploads public key" {
+    run_deployer aws:key:add \
+        --name="$AWS_TEST_KEY_NAME" \
+        --public-key-path="$CLOUD_TEST_KEY_PATH"
+
+    debug_output
+
+    [ "$status" -eq 0 ]
+    assert_success_output
+    assert_output_contains "Key pair imported successfully"
+    assert_command_replay "aws:key:add"
+}
+```
+
+### Example: Credential Guard Pattern
+
+```bash
+@test "aws:provision creates EC2 instance" {
+    require_aws_provision_config
+
+    run_deployer aws:provision \
+        --name="$AWS_TEST_SERVER_NAME" \
+        --instance-type="$AWS_TEST_INSTANCE_TYPE" \
+        # ... more options
+
+    debug_output
+
+    [ "$status" -eq 0 ]
+    assert_success_output
+}
+```
+
+### Example: Full Lifecycle Test
+
+```bash
+@test "aws:provision full lifecycle: provision -> install -> deploy -> verify -> cleanup" {
+    require_aws_provision_config
+
+    # Provision server
+    run_deployer aws:provision --name="$AWS_TEST_SERVER_NAME" ...
+    [ "$status" -eq 0 ]
+
+    # Get server IP for later verification
+    local server_ip
+    server_ip=$(get_server_ip "$AWS_TEST_SERVER_NAME")
+
+    # Install server (PHP, Nginx, etc.)
+    run_deployer server:install --server="$AWS_TEST_SERVER_NAME" ...
+    [ "$status" -eq 0 ]
+
+    # Create and deploy site
+    run_deployer site:create --server="$AWS_TEST_SERVER_NAME" --domain="$AWS_TEST_DOMAIN" ...
+    [ "$status" -eq 0 ]
+
+    run_deployer site:deploy --domain="$AWS_TEST_DOMAIN" ...
+    [ "$status" -eq 0 ]
+
+    # Verify deployment (bypass DNS using direct IP)
+    wait_for_http "$AWS_TEST_DOMAIN" "$CLOUD_TEST_APP_MESSAGE" 180 "$server_ip"
+
+    # Cleanup
+    cleanup_test_site "$AWS_TEST_DOMAIN"
+    aws_cleanup_test_server
+}
+```
+
+### Example: Test Side Effect
+
+```bash
+@test "command creates expected files on remote" {
+    add_test_server
+    assert_remote_file_exists "/home/deployer/.ssh/id_ed25519"
+    assert_remote_dir_exists "/home/deployer/sites"
+}
+```
+
+## Rules
+
+- Use `--yes` / `-y` to skip confirmations
+- Use `--force` / `-f` to skip type-to-confirm prompts
+- Input validation and failure-path tests belong in PHP unit tests
+- Each distro has isolated VM instance and SSH port
+- Interactive-only behavior cannot be tested in BATS
+- Cloud tests **fail** with diagnostics when provider credentials are missing — no silent skips
+- Use `require_*` guards in `setup_file()`, `setup()`, and per-test; use raw `*_available()` only in `teardown_file()` (cleanup must always attempt)
+- Use `setup_file()` for preventive cleanup and `teardown_file()` for reactive cleanup, `setup()` for per-test credential checks

--- a/.agents/skills/deployerphp-command-authoring/SKILL.md
+++ b/.agents/skills/deployerphp-command-authoring/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: deployerphp-command-authoring
+description: Author and modify DeployerPHP Symfony Console commands and Traits, including prompt-to-option parity, early conflict validation, validator usage, command replay behavior, and registration in SymfonyApp. Use when editing app/Console/*, app/Traits/*, command wiring, or command-focused tests.
+---
+
+# Command Authoring
+
+Use this skill when a task changes command input/output flow, options, shared
+trait behavior, or command registration.
+
+## Protocol
+
+1. Read `references/command-trait-rules.md` before editing code.
+2. Apply the command/trait rules exactly (prompt/option parity, no proxy
+   commands, early option conflict checks, and replay requirements).
+3. Keep validator and exception-handling patterns consistent with the
+   reference examples.
+4. After command changes, ensure command documentation expectations remain in
+   sync (route to docs policy skill when docs edits are needed).
+
+## References
+
+- `references/command-trait-rules.md` - full rules and examples migrated from
+  `AGENTS.md`.

--- a/.agents/skills/deployerphp-command-authoring/references/command-trait-rules.md
+++ b/.agents/skills/deployerphp-command-authoring/references/command-trait-rules.md
@@ -1,0 +1,466 @@
+# Command & Trait Rules
+
+Commands are Symfony Console classes that handle user I/O. Traits provide shared command behavior. Both use Laravel Prompts via `$this->io` wrapper methods and BaseCommand methods for output.
+
+> **IMPORTANT**
+>
+> - Every prompt MUST have a corresponding CLI option
+> - Never invoke other commands (NO proxy commands)
+> - Validate conflicting options immediately after `parent::execute()` (early validation)
+> - NEVER use `getOptionOrPrompt()` directly - it's private
+> - New commands MUST be registered in `SymfonyApp.php` (import + add to `$commands` array)
+> - **After command changes:** Use the `deployerphp-docs-policy` skill when documentation edits are needed
+
+## Context
+
+### Non-Interactive Design
+
+Commands support both interactive and non-interactive execution through a simple pattern: **options replace prompts**.
+
+**How it works:**
+
+1. If CLI option provided → skip the prompt, use the option value
+2. If CLI option omitted → show the interactive prompt
+3. `commandReplay()` outputs the full non-interactive command with all selected values
+
+**Benefits:**
+
+- Users can run partially with options and fill in the rest interactively
+- Command replay teaches users the full CLI syntax for automation
+- No complex "is this required in non-interactive mode?" validation logic
+- Easy to add new prompts/options without updating validation rules
+
+Falling through to interactive prompts when CLI options are omitted is the intended pattern, not a bug.
+
+### Output Methods
+
+Use BaseCommand methods. Never use SymfonyStyle directly.
+
+- `yay`, `nay`, `warn`, `info`, `out`
+- `h1`, `hr`
+- `displayDeets`, `ul`, `ol`
+
+### Input Method Selection
+
+| Input Type             | Method                         | Validation  |
+| ---------------------- | ------------------------------ | ----------- |
+| Boolean (confirm/flag) | `getBooleanOptionOrPrompt()`   | None needed |
+| String/array           | `getValidatedOptionOrPrompt()` | Required    |
+
+### Validator Naming Convention
+
+| Pattern            | Returns   | Use Case                |
+| ------------------ | --------- | ----------------------- |
+| `validate*Input()` | `?string` | Prompts and CLI options |
+| `validate*()`      | throws    | Heavy I/O validation    |
+
+### Command Options Naming
+
+| Option           | Usage                    | Type           |
+| ---------------- | ------------------------ | -------------- |
+| `--server`       | Select existing server   | VALUE_REQUIRED |
+| `--domain`       | Select existing site     | VALUE_REQUIRED |
+| `--name`         | Define new resource name | VALUE_REQUIRED |
+| `--yes` / `-y`   | Skip confirmation        | VALUE_NONE     |
+| `--force` / `-f` | Skip type-to-confirm     | VALUE_NONE     |
+
+`--server`/`--domain` for SELECTING existing resources, `--name` for DEFINING new ones.
+
+## Examples
+
+### Example: Command Structure
+
+```php
+#[AsCommand(name: 'namespace:action', description: 'Brief description')]
+final class ActionCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->addOption('name', null, InputOption::VALUE_REQUIRED, 'Resource name');
+        $this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $name = $this->io->getValidatedOptionOrPrompt(
+                'name',
+                fn ($validate) => $this->io->promptText(label: 'Name:', validate: $validate),
+                fn ($value) => $this->validateNameInput($value)
+            );
+        } catch (ValidationException $e) {
+            $this->nay($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->service->doSomething($name);
+        $this->yay("Created {$name}");
+        $this->commandReplay('namespace:action', ['name' => $name, 'yes' => true]);
+        return Command::SUCCESS;
+    }
+
+}
+```
+
+### Example: Trait Structure
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace DeployerPHP\Traits;
+
+use DeployerPHP\DTOs\ServerDTO;
+use DeployerPHP\Exceptions\ValidationException;
+use Symfony\Component\Console\Command\Command;
+
+trait ServersTrait
+{
+    /**
+     * Select a server from inventory.
+     *
+     * @throws ValidationException When CLI validation fails
+     */
+    protected function selectServer(): ServerDTO
+    {
+        $name = $this->io->getValidatedOptionOrPrompt(
+            'server',
+            fn ($validate) => $this->io->promptSelect(
+                label: 'Select server:',
+                options: $this->getServerOptions(),
+                validate: $validate
+            ),
+            fn ($value) => $this->validateServerSelection($value)
+        );
+
+        /** @var ServerDTO */
+        return $this->servers->findByName($name);
+    }
+
+    protected function validateServerSelection(mixed $name): ?string
+    {
+        if (!is_string($name)) {
+            return 'Server name must be a string';
+        }
+        if (null === $this->servers->findByName($name)) {
+            return "Server '{$name}' not found in inventory";
+        }
+        return null;
+    }
+}
+```
+
+### Example: Trait Exception Handling
+
+```php
+// In trait - throws, doesn't catch
+protected function selectServer(): ServerDTO
+{
+    $name = $this->io->getValidatedOptionOrPrompt(...);  // May throw
+    return $this->servers->findByName($name);
+}
+
+// In command - catches at execute() level
+protected function execute(...): int
+{
+    try {
+        $server = $this->selectServer();  // Trait method
+        $site = $this->selectSite();      // Trait method
+    } catch (ValidationException $e) {
+        $this->nay($e->getMessage());
+        return Command::FAILURE;
+    }
+    // ...
+}
+```
+
+### Example: Non-Interactive Fallback
+
+```php
+// Option provided → uses CLI value, skips prompt
+// Option omitted → falls through to interactive prompt
+if ($generateKey) {
+    $deployKeyPath = null;
+} elseif ($customKeyPath !== null) {
+    $deployKeyPath = $this->promptDeployKeyPairPath();
+} else {
+    // Interactive fallback - this is VALID, not an error
+    $choice = $this->io->promptSelect(
+        label: 'Deploy key:',
+        options: ['generate' => '...', 'custom' => '...'],
+    );
+    $deployKeyPath = ($choice === 'generate') ? null : $this->promptDeployKeyPairPath();
+}
+```
+
+### Example: Validation Exception
+
+```php
+use DeployerPHP\Exceptions\ValidationException;
+
+// IoService throws on validation failure (CLI mode)
+// Interactive prompts re-prompt until valid, so no exception there
+try {
+    $name = $this->io->getValidatedOptionOrPrompt(...);
+    $host = $this->io->getValidatedOptionOrPrompt(...);
+    $port = $this->io->getValidatedOptionOrPrompt(...);
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage()); // Display the validation error
+    return Command::FAILURE;
+}
+// All values guaranteed valid after try-catch
+```
+
+### Example: Validator Signature
+
+```php
+protected function validateNameInput(mixed $value): ?string
+{
+    if (!is_string($value)) {
+        return 'Name must be a string';
+    }
+    if ('' === trim($value)) {
+        return 'Name cannot be empty';
+    }
+    if (null !== $this->repo->findByName($value)) {
+        return "'{$value}' already exists";
+    }
+
+    return null;
+}
+```
+
+### Example: Boolean Flag Simple
+
+```php
+// Definition
+$this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation');
+
+// Usage: --yes or -y
+$skipConfirm = $this->input->getOption('yes');
+```
+
+### Example: Boolean Flag Tristate
+
+```php
+// Definition
+$this->addOption('php-default', null, InputOption::VALUE_NEGATABLE, 'Set as default PHP');
+
+// Usage: --php-default (true), --no-php-default (false), omitted (null/prompt)
+$phpDefault = $this->input->getOption('php-default');
+if (null === $phpDefault) {
+    $phpDefault = $this->promptConfirm('Set as default PHP?');
+}
+```
+
+### Example: Boolean Prompt
+
+```php
+$confirmed = $this->io->getBooleanOptionOrPrompt(
+    'yes',
+    fn () => $this->io->promptConfirm('Proceed?')
+);
+```
+
+### Example: Validated String
+
+```php
+// Throws ValidationException on CLI validation failure
+// Wrap in try-catch to handle gracefully
+try {
+    $name = $this->io->getValidatedOptionOrPrompt(
+        'name',
+        fn ($validate) => $this->io->promptText(label: 'Name:', validate: $validate),
+        fn ($value) => $this->validateNameInput($value)
+    );
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage());
+    return Command::FAILURE;
+}
+```
+
+### Example: Multiselect CLI
+
+```php
+try {
+    $selected = $this->io->getValidatedOptionOrPrompt(
+        'databases',
+        fn ($validate) => $this->io->promptMultiselect(label: 'Databases:', options: $options),
+        fn ($value) => $this->validateDatabasesInput($value, $options)
+    );
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage());
+    return Command::FAILURE;
+}
+
+// Normalize: CLI gives string, prompt gives array
+if (is_string($selected)) {
+    $selected = array_filter(array_map(trim(...), explode(',', $selected)));
+}
+```
+
+### Example: Multi-Path Options
+
+```php
+// In configure()
+$this->addOption('generate-deploy-key', null, InputOption::VALUE_NONE, 'Generate new deploy key');
+$this->addOption('custom-deploy-key', null, InputOption::VALUE_REQUIRED, 'Path to existing key');
+
+// In execute() - early validation block (right after parent::execute())
+if ($generateKey && null !== $customKeyPath) {
+    $this->nay('Cannot use both --generate-deploy-key and --custom-deploy-key');
+    return Command::FAILURE;
+}
+
+// Later in execute() - after header and server selection
+if (!$generateKey && null === $customKeyPath) {
+    $choice = $this->io->promptSelect(...);
+    // ...
+}
+```
+
+### Example: Confirmation Simple
+
+```php
+// Definition
+$this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation');
+
+// Usage
+$confirmed = $this->io->getBooleanOptionOrPrompt('yes', fn () => $this->io->promptConfirm('Proceed?'));
+if (! $confirmed) {
+    return Command::SUCCESS;
+}
+```
+
+### Example: Confirmation Destructive
+
+```php
+// Definition
+$this->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip type-to-confirm');
+
+// Usage
+$forceSkip = $this->input->getOption('force');
+if (!$forceSkip) {
+    $typedName = $this->promptText(label: "Type '{$server->name}' to confirm deletion:");
+    if ($typedName !== $server->name) {
+        $this->nay('Name does not match. Aborting.');
+        return Command::FAILURE;
+    }
+}
+```
+
+### Example: Command Replay
+
+```php
+$this->commandReplay('server:delete', [
+    'server' => $server->name,
+    'yes' => true,
+]);
+
+return Command::SUCCESS;
+```
+
+### Example: Wrong No Try-Catch
+
+```php
+// WRONG - No try-catch around validated input
+$value = $this->io->getValidatedOptionOrPrompt(...);
+$this->doSomething($value);  // Throws ValidationException if CLI validation fails!
+
+// CORRECT - Wrap in try-catch
+try {
+    $value = $this->io->getValidatedOptionOrPrompt(...);
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage());
+    return Command::FAILURE;
+}
+```
+
+### Example: Wrong No Validator
+
+```php
+// WRONG - No validator for string input
+$env = $this->io->promptSelect('Environment:', $options);
+// User CLI option --env=invalid passes through! Always use getValidatedOptionOrPrompt.
+
+// CORRECT - Always validate string/array inputs
+try {
+    $env = $this->io->getValidatedOptionOrPrompt(
+        'env',
+        fn ($validate) => $this->io->promptSelect('Environment:', $options),
+        fn ($value) => $this->validateEnvInput($value, $options)
+    );
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage());
+    return Command::FAILURE;
+}
+```
+
+### Example: Wrong Separate Try-Catch
+
+```php
+// WRONG - Separate try-catch for each input (verbose)
+try {
+    $name = $this->io->getValidatedOptionOrPrompt(...);
+} catch (ValidationException $e) { ... }
+try {
+    $host = $this->io->getValidatedOptionOrPrompt(...);
+} catch (ValidationException $e) { ... }
+
+// CORRECT - Group related inputs in single try-catch
+try {
+    $name = $this->io->getValidatedOptionOrPrompt(...);
+    $host = $this->io->getValidatedOptionOrPrompt(...);
+} catch (ValidationException $e) {
+    $this->nay($e->getMessage());
+    return Command::FAILURE;
+}
+```
+
+### Example: Wrong Late Validation
+
+```php
+// WRONG - Late validation (after SSH/playbook calls)
+protected function execute(...): int
+{
+    $this->h1('Install Service');
+    $server = $this->selectServerDeets();  // SSH connection here
+    $this->executePlaybook($server, 'some-playbook', '...');  // Network I/O here
+
+    // TOO LATE - validation happens after expensive operations
+    if ($optionA && $optionB) {
+        $this->nay('Cannot use both...');
+        return Command::FAILURE;
+    }
+
+}
+
+// CORRECT - Early validation (before any I/O)
+protected function execute(...): int
+{
+    parent::execute($input, $output);
+
+    // Validate FIRST, before header
+    if ($optionA && $optionB) {
+        $this->nay('Cannot use both...');
+        return Command::FAILURE;
+    }
+
+    $this->h1('Install Service');
+    $server = $this->selectServerDeets();
+    // ...
+
+}
+```
+
+## Rules
+
+- Traits let `ValidationException` propagate to commands - never catch in traits
+- Group related validated inputs in single try-catch block
+- `validate*Input()` returns `?string`; `validate*()` throws exceptions
+- Always call `commandReplay()` before returning `Command::SUCCESS`
+- Validate conflicting options BEFORE any I/O (early validation)
+- Booleans use `getBooleanOptionOrPrompt()`; strings/arrays use `getValidatedOptionOrPrompt()`
+- Multi-path prompts need separate options, conflict detection in early validation

--- a/.agents/skills/deployerphp-docs-policy/SKILL.md
+++ b/.agents/skills/deployerphp-docs-policy/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: deployerphp-docs-policy
+description: Apply DeployerPHP documentation policy for docs/* updates, including master index maintenance, command replay documentation approach, option-doc restrictions, TOC conventions, and formatting workflow. Use when editing documentation files.
+---
+
+# Documentation Policy
+
+Use this skill for documentation updates in `docs/` or user-facing markdown.
+
+## Protocol
+
+1. Read `references/documentation-rules.md` before editing docs.
+2. Apply policy constraints (master index updates, TOC requirements, and
+   command replay framing).
+3. Keep docs behavior-focused and avoid brittle CLI option enumerations.
+4. Run required formatting steps when documentation is modified.
+
+## References
+
+- `references/documentation-rules.md` - full documentation rules and examples
+  migrated from `AGENTS.md`.

--- a/.agents/skills/deployerphp-docs-policy/references/documentation-rules.md
+++ b/.agents/skills/deployerphp-docs-policy/references/documentation-rules.md
@@ -1,0 +1,82 @@
+# Documentation Rules
+
+Rules for writing DeployerPHP user documentation.
+
+> **IMPORTANT**
+>
+> - **Master index**: `docs/documentation.md` lists all doc files - update it when adding new files
+> - **No CLI option docs**: Commands show a "non-interactive command replay" automatically
+
+## Rules
+
+- **Master index updates**: When adding a new documentation file (e.g., `docs/new-feature.md`), add it to `docs/documentation.md`. Do NOT update the master index for subsections within existing files.
+- **No non-interactive command examples**: DeployerPHP commands display a "Non-interactive command replay" at the end of each execution. Don't duplicate this in docs—instead, mention that the replay is shown automatically.
+- **No specific option/parameter references**: Don't document specific CLI options like `--keep-releases` or `--lines`. Commands show a "non-interactive command replay" with all options at the end of execution. This keeps docs maintainable—we don't need to update them when options change.
+- **Explain what commands do, not what they output**: Describe the prompts, steps, and outcomes in prose rather than showing verbose terminal output or tables of parameter options.
+- **Keep it scannable**: Use bullet lists for prompts, numbered lists for sequential steps.
+- **TOC required**: Every documentation file must include a Table of Contents at the top, wrapped in `<!-- toc -->` and `<!-- /toc -->` HTML comment delimiters. List all H2 sections as links using kebab-case anchors.
+- **Allowed callouts**: Use only `[!NOTE]` and `[!IMPORTANT]` callouts in docs.
+- **Callout sequencing**: Do not place two callouts of the same type consecutively. Alternate types when two adjacent callouts are needed.
+
+### Example: TOC Structure
+
+```markdown
+<!-- toc -->
+
+- [Section One](#section-one)
+- [Section Two](#section-two)
+- [Section Three](#section-three)
+
+<!-- /toc -->
+```
+
+### Example: Describe Prompts
+
+```markdown
+DeployerPHP will prompt you for:
+
+- **Server name** - A friendly name for your server (e.g., "production", "web1")
+- **Host** - The IP address or hostname of your server
+- **Port** - SSH port (default: 22)
+```
+
+### Example: Describe Steps
+
+```markdown
+The installation process will:
+
+1. Update package lists and install base packages
+2. Configure Nginx with a monitoring endpoint
+3. Set up the firewall (UFW)
+4. Install your chosen PHP version with selected extensions
+```
+
+### Example: Describe Behavior Without Options
+
+Instead of documenting specific options:
+
+```markdown
+<!-- DON'T -->
+
+Use the `--lines` option to control output, or `--site` to filter logs.
+
+<!-- DO -->
+
+You can customize the output when running the command.
+```
+
+### Example: Anchor Pattern
+
+```markdown
+<a name="section-name"></a>
+
+## Section Name
+```
+
+## Formatting
+
+After modifying docs, run prettier:
+
+```shell
+bunx prettier --write "docs/**/*.md"
+```

--- a/.agents/skills/deployerphp-gha-ci/SKILL.md
+++ b/.agents/skills/deployerphp-gha-ci/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: deployerphp-gha-ci
+description: Author and maintain DeployerPHP GitHub Actions workflows and CI contracts, including setup-php-composer usage, timeout/concurrency patterns, matrix configuration, cloud-test environment wiring, cleanup backstops, and permissions/trigger constraints. Use when editing .github/workflows/* or related CI automation.
+---
+
+# GitHub Actions CI
+
+Use this skill for workflow design and CI pipeline changes.
+
+## Protocol
+
+1. Read `references/github-actions-rules.md` before editing workflows.
+2. Apply workflow-category constraints (quality-gate vs integration patterns)
+   and timeout/concurrency standards.
+3. Keep secrets/vars boundaries, permissions, and triggers aligned with policy.
+4. Preserve cloud test env wiring and backstop cleanup behavior.
+
+## References
+
+- `references/github-actions-rules.md` - full workflow rules and examples
+  migrated from `AGENTS.md`.

--- a/.agents/skills/deployerphp-gha-ci/references/github-actions-rules.md
+++ b/.agents/skills/deployerphp-gha-ci/references/github-actions-rules.md
@@ -1,0 +1,295 @@
+# GitHub Actions Rules
+
+Rules for GitHub Actions workflows, reusable actions, and CI/CD configuration in DeployerPHP.
+
+> **IMPORTANT**
+>
+> - Use `setup-php-composer` action for all PHP workflows
+> - Quality gate workflows must complete in under 3 minutes
+> - Integration test workflows use `fail-fast: false` for comprehensive coverage
+
+## Context
+
+### Workflow Categories
+
+| Category          | Trigger        | Timeout | Purpose                      |
+| ----------------- | -------------- | ------- | ---------------------------- |
+| Quality Gates     | `pull_request` | 3min    | Fast feedback on PR quality  |
+| Integration Tests | `pull_request` | 9min    | Real-world testing           |
+| Automation        | Various        | N/A     | Dependabot automation        |
+
+**Quality Gate Workflows:**
+
+- `pest.yml` - Unit tests with coverage
+- `phpstan.yml` - Static analysis
+- `pint.yml` - Code style
+- `rector.yml` - Automated refactoring checks
+- `ci-canary.yml` - Verify linters catch known violations
+
+**Integration Test Workflows:**
+
+- `bats-vm.yml` - Server command tests (Lima VMs, 3-distro matrix)
+- `bats-cloud.yml` - Cloud provider tests (AWS/DO matrix)
+
+**Automation Workflows:**
+
+- `dependabot-automerge.yml` - Auto-approve and merge dependabot PRs
+
+### Directory Structure
+
+```text
+.github/
+├── workflows/
+│   ├── pest.yml              # Unit tests
+│   ├── phpstan.yml           # Static analysis
+│   ├── pint.yml              # Code style
+│   ├── rector.yml            # Automated refactoring
+│   ├── ci-canary.yml         # Linter verification
+│   ├── bats-vm.yml           # VM integration tests
+│   ├── bats-cloud.yml        # Cloud integration tests
+│   └── dependabot-automerge.yml
+├── actions/
+│   └── setup-php-composer/
+│       └── action.yml        # Reusable PHP setup
+└── dependabot.yml            # Dependency update config
+```
+
+### Reusable Action: setup-php-composer
+
+All PHP workflows use the local composite action for consistent setup:
+
+```yaml
+- name: Setup PHP and Composer
+  uses: ./.github/actions/setup-php-composer
+  with:
+      php-version: '8.2' # Optional, default: 8.2
+      coverage: 'true' # Optional, default: false (enables xdebug)
+```
+
+**Inputs:**
+
+| Input         | Default | Description                |
+| ------------- | ------- | -------------------------- |
+| `php-version` | `8.2`   | PHP version to install     |
+| `coverage`    | `false` | Enable xdebug for coverage |
+
+### Secrets vs Variables
+
+**Secrets (sensitive, encrypted):**
+
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
+- `AWS_TEST_INSTANCE_TYPE`, `AWS_TEST_DISK_SIZE`
+- `DO_API_TOKEN`
+- `CF_API_TOKEN`
+- `SSH_PRIVATE_KEY_B64` (base64-encoded SSH key)
+- `DOTENV_FILE` (full .env file contents)
+
+**Variables (public infrastructure IDs):**
+
+- `AWS_TEST_IMAGE`, `AWS_TEST_KEY_PAIR`, `AWS_TEST_VPC`, `AWS_TEST_SUBNET`
+- `AWS_TEST_HOSTED_ZONE`, `AWS_TEST_DOMAIN`
+- `DO_TEST_SSH_KEY_ID`, `DO_TEST_REGION`, `DO_TEST_SIZE`, `DO_TEST_IMAGE`, `DO_TEST_VPC_UUID`
+- `DO_TEST_DOMAIN`, `CF_TEST_DOMAIN`
+
+## Examples
+
+### Example: Quality Gate Workflow
+
+```yaml
+name: PHPStan
+
+permissions:
+    contents: read
+
+on:
+    pull_request:
+
+jobs:
+    phpstan:
+        runs-on: ubuntu-latest
+        timeout-minutes: 3
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}
+            cancel-in-progress: true
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PHP and Composer
+              uses: ./.github/actions/setup-php-composer
+
+            - name: Run static analysis
+              run: vendor/bin/phpstan analyse --error-format=github
+```
+
+### Example: Integration Test with Matrix
+
+```yaml
+name: BATS VM Tests
+
+permissions:
+    contents: read
+
+on:
+    pull_request:
+
+jobs:
+    vm-tests:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 9
+
+        strategy:
+            fail-fast: false
+            matrix:
+                distro: [ubuntu24]
+
+        concurrency:
+            group: bats-vm-${{ matrix.distro }}-${{ github.ref }}
+            cancel-in-progress: true
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup-php-composer
+
+            - name: Run VM tests for ${{ matrix.distro }}
+              env:
+                  CI: 'true'
+                  BATS_DISTRO: ${{ matrix.distro }}
+              run: ./bats.sh ci vm ${{ matrix.distro }}
+```
+
+### Example: Cloud Test Job-Level Env Vars
+
+Cloud test credentials and config are defined at **job level** (not step level), so all steps share them:
+
+```yaml
+jobs:
+    cloud-tests:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 9
+        env:
+            CI: 'true'
+            BATS_RUN_SUFFIX: ${{ github.run_id }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_TEST_IMAGE: ${{ vars.AWS_TEST_IMAGE }}
+            DO_API_TOKEN: ${{ secrets.DO_API_TOKEN }}
+            # ... all provider vars
+        steps:
+            - run: ./bats.sh ci cloud ${{ matrix.provider }}
+```
+
+### Run-Scoped Resource Isolation
+
+Cloud CI jobs must set `BATS_RUN_SUFFIX: ${{ github.run_id }}` at job scope.
+
+Resource naming rules (servers, keys, DNS roots, secondary `.v2` domains) are
+defined in one place: `# BATS Rules` → `Run-Scoped Resource Isolation (Cloud)`
+and implemented in `tests/bats/lib/cloud-helpers.bash`.
+
+### Backstop Cleanup
+
+Cloud tests use a two-tier `if: always()` cleanup step after the test run:
+
+1. **Tier 1 — Deployer CLI:** Attempts cleanup through normal deployer commands
+2. **Tier 2 — Raw cloud CLI:** Falls back to `aws` CLI / DO API `curl` if Deployer itself is broken
+
+This is intentionally duplicated inline (not shared from BATS helpers) so cleanup works even if the helper code is the source of failure.
+
+### Example: Adding a New Quality Gate
+
+```yaml
+name: New Check
+
+permissions:
+    contents: read
+
+on:
+    pull_request:
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        timeout-minutes: 3
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}
+            cancel-in-progress: true
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup-php-composer
+            - run: vendor/bin/some-tool --check
+```
+
+### Example: Adding Integration Test Matrix Entry
+
+To add a new distro to VM tests:
+
+```yaml
+strategy:
+    fail-fast: false
+    matrix:
+        distro: [ubuntu24, new-distro] # Add here
+```
+
+To add a new cloud provider:
+
+```yaml
+strategy:
+    fail-fast: false
+    matrix:
+        provider: [aws, do, new-provider] # Add here
+```
+
+## Rules
+
+### Workflow Patterns
+
+- Quality gates: 3-minute timeout, PR trigger, `ubuntu-latest`
+- Integration tests: 9 minute timeout, PR trigger, `ubuntu-24.04`
+- Cloud tests: skip fork PRs with `if: ${{ github.event.pull_request.head.repo.fork == false }}` (forks cannot access secrets)
+- Always use `concurrency` to cancel superseded runs
+- Matrix jobs use `fail-fast: false` for comprehensive coverage
+
+### Concurrency Groups
+
+```yaml
+# Quality gates: group by workflow and ref
+group: ${{ github.workflow }}-${{ github.ref }}
+
+# Matrix jobs: include matrix key to allow parallel matrix entries
+group: bats-vm-${{ matrix.distro }}-${{ github.ref }}
+group: bats-cloud-${{ matrix.provider }}-${{ github.ref }}
+```
+
+### Permissions
+
+- Use minimal permissions for each workflow
+- Quality gates: `contents: read`
+- Dependabot automerge: `pull-requests: write`, `contents: write`
+
+### Triggers
+
+- Quality gates: `pull_request`
+- Integration tests: `pull_request`
+
+### Environment Files
+
+Cloud tests load credentials from `.env` file:
+
+```yaml
+- name: Setup environment file
+  run: |
+      cat <<'EOF' > .env
+      ${{ secrets.DOTENV_FILE }}
+      EOF
+```
+
+## Constraints
+
+- Never commit workflow changes directly to main
+- Use `ci/*` branches to test workflow changes
+- All PR checks must pass before merge
+- Never store secrets in variables (use encrypted secrets)
+- Quality gate timeouts must not exceed 3 minutes
+- Always use setup-php-composer for PHP workflows (ensures caching)

--- a/.agents/skills/deployerphp-playbook-authoring/SKILL.md
+++ b/.agents/skills/deployerphp-playbook-authoring/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: deployerphp-playbook-authoring
+description: Author and update DeployerPHP playbooks with idempotent bash, DEPLOYER_* environment validation, helper usage, YAML output contracts, credential patterns, and logging/logrotate conventions. Use when editing playbooks/* or playbook-adjacent command behavior.
+---
+
+# Playbook Authoring
+
+Use this skill when tasks modify provisioning/install/deploy shell playbooks.
+
+## Protocol
+
+1. Read `references/playbook-rules.md` before making playbook edits.
+2. Keep scripts idempotent, non-interactive, and aligned with required
+   environment-variable validation and output contracts.
+3. Follow helper usage and bash-style constraints from the reference.
+4. Preserve logging and logrotate lifecycle behavior when resources are created
+   or removed.
+
+## References
+
+- `references/playbook-rules.md` - full playbook rules and examples migrated
+  from `AGENTS.md`.

--- a/.agents/skills/deployerphp-playbook-authoring/references/playbook-rules.md
+++ b/.agents/skills/deployerphp-playbook-authoring/references/playbook-rules.md
@@ -1,0 +1,457 @@
+# Playbook Rules
+
+Playbooks are idempotent, non-interactive bash scripts that execute server tasks remotely. They receive context via environment variables and return YAML output. Bash style: <https://style.ysap.sh/md>
+
+> **IMPORTANT**
+>
+> - Shebang `#!/usr/bin/env bash` always first line
+> - `set -o pipefail` (NEVER use `set -e`)
+> - `export DEBIAN_FRONTEND=noninteractive`
+> - Validate ALL `DEPLOYER_*` variables before any work
+> - NEVER use `eval`
+> - Prefer OS-native packages; use third-party repos only when the package is unavailable
+
+## Context
+
+### Environment Variables
+
+All variables use `DEPLOYER_` prefix:
+
+- `DEPLOYER_OUTPUT_FILE` - YAML output path (always required)
+- `DEPLOYER_PERMS` - Permissions: `root|sudo|none`
+
+### Available Helpers
+
+These are automatically inlined from `helpers.sh`. Never manually inline helpers into playbook files.
+
+| Function             | Purpose                                             |
+| -------------------- | --------------------------------------------------- |
+| `run_cmd`            | Execute with appropriate permissions (root or sudo) |
+| `run_as_deployer`    | Execute as deployer user with env preservation      |
+| `fail "message"`     | Print error and exit                                |
+| `detect_php_default` | Get default PHP version                             |
+| `wait_for_dpkg_lock` | Wait for package manager lock                       |
+| `apt_get_with_retry` | apt-get with automatic retry on lock                |
+
+See `playbooks/server-info.sh` for a simple example.
+
+### Guaranteed System Tools
+
+These tools are installed by `base-install.sh` and available in all playbooks without existence checks:
+
+| Tool         | Purpose              |
+| ------------ | -------------------- |
+| `jq`         | JSON parsing         |
+| `curl`       | HTTP requests        |
+| `rsync`      | File synchronization |
+| `git`        | Version control      |
+| `supervisor` | Process management   |
+| `nginx`      | Web server           |
+| `certbot`    | SSL certificates     |
+| `ufw`        | Firewall management  |
+
+Do NOT add `command -v` checks for these tools - they are guaranteed on provisioned servers.
+
+### Bash Style Rules
+
+**Conditionals:** `[[ ... ]]` not `[ ... ]`
+
+**Command Substitution:** `$(...)` not backticks
+
+**Math:** `((...))` and `$((...))`, never `let`
+
+**Functions:** No `function` keyword, always use `local`
+
+**Block Statements:** `then`/`do` on same line
+
+**Expansion:** Prefer over external commands (`${0##*/}` not `basename "$0"`)
+
+**Quoting:** Double for expansions, single for literals. `[[ ]]` doesn't word-split.
+
+**Arrays:** Use bash arrays, not strings
+
+**Formatting:** Tabs for indentation, max 80 columns, max 1 blank line between sections
+
+### Code Organization
+
+- Section comments: `# ----` + `# Section Name` + `# ----`
+- Function comments: `#` + blank + `# Description`
+- Group related functions into sections
+- Order functions alphabetically within sections
+- Place `main()` at the bottom
+
+### Credential Generation
+
+| Service Type | Username Pattern | Example         |
+| ------------ | ---------------- | --------------- |
+| Database     | `deployer`       | `deployer`      |
+| Admin panel  | `admin`          | `admin`         |
+| Service auth | `{service}_user` | `rabbitmq_user` |
+
+Use `openssl rand -base64 24` for secure passwords.
+
+### Service Logging
+
+**Systemd services:** Automatic journalctl integration - no configuration needed.
+
+**File-based logs:**
+
+| Service Type   | Log Path Pattern                    |
+| -------------- | ----------------------------------- |
+| Direct service | `/var/log/{service}*.log`           |
+| Subdirectory   | `/var/log/{service}/*.log`          |
+| Per-site       | `/var/log/{service}/{domain}-*.log` |
+
+### Log Rotation
+
+Default to built-in rotation. Only create custom configs when:
+
+1. Service has no built-in rotation (unlike Nginx)
+2. System package provides no default config (unlike PHP-FPM)
+3. You need per-resource rotation (e.g., per-site, per-program)
+
+| Strategy       | When to Use                                      |
+| -------------- | ------------------------------------------------ |
+| `copytruncate` | Service keeps file handles open (Supervisor)     |
+| `postrotate`   | Service supports signal/reload for log reopening |
+
+## Examples
+
+### Example: Playbook Structure
+
+```bash
+#!/usr/bin/env bash
+
+#
+
+# {Playbook Name} Playbook - Ubuntu Only
+
+#
+
+# {Brief description of what this playbook does}
+
+# ----
+
+#
+
+# {Detailed description including:}
+
+# {- What the playbook installs/configures}
+
+# {- Prerequisites or dependencies}
+
+# {- Any important notes}
+
+#
+
+# Required Environment Variables:
+
+# DEPLOYER_OUTPUT_FILE - Output file path
+
+# DEPLOYER_PERMS - Permissions: root|sudo|none
+
+# {DEPLOYER_CUSTOM_VAR} - {Description}
+
+#
+
+# Returns YAML with:
+
+# - status: success
+
+# - {key}: {description}
+
+#
+
+set -o pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+[[ -z $DEPLOYER_OUTPUT_FILE ]] && echo "Error: DEPLOYER_OUTPUT_FILE required" && exit 1
+[[ -z $DEPLOYER_PERMS ]] && echo "Error: DEPLOYER_PERMS required" && exit 1
+
+# Add validation for custom variables here
+
+export DEPLOYER_PERMS
+
+# Shared helpers are automatically inlined when executing playbooks remotely
+
+# source "$(dirname "$0")/helpers.sh"
+
+# ----
+
+# {Section Name} Functions
+
+# ----
+
+#
+
+# {Function description}
+
+function_name() { # Implementation
+}
+
+# ----
+
+# Main Execution
+
+# ----
+
+main() { # Execute tasks
+function_name
+
+    # Write output YAML
+    if ! cat > "$DEPLOYER_OUTPUT_FILE" <<EOF; then
+status: success
+EOF
+        echo "Error: Failed to write output file" >&2
+        exit 1
+    fi
+
+}
+
+main "$@"
+```
+
+### Example: Idempotency Command
+
+```bash
+# Command existence
+if ! command -v nginx >/dev/null 2>&1; then
+    echo "→ Installing Nginx..."
+    run_cmd apt-get install -y -q nginx
+fi
+```
+
+### Example: Idempotency Directory
+
+```bash
+# Directory existence
+if ! run_cmd test -d /var/www/app; then
+    echo "→ Creating /var/www/app..."
+    run_cmd mkdir -p /var/www/app
+fi
+```
+
+### Example: Idempotency File
+
+```bash
+# File existence
+if ! run_cmd test -f "$config_file"; then
+    echo "→ Creating configuration..."
+    run_cmd tee "$config_file" > /dev/null <<- 'EOF'
+        # config content
+    EOF
+fi
+```
+
+### Example: Idempotency Marker
+
+```bash
+# Config content marker
+if ! grep -q "DEPLOYER-MARKER" /etc/config 2>/dev/null; then
+    echo "→ Updating configuration..."
+    # modify config
+fi
+```
+
+### Example: Idempotency Service
+
+```bash
+# Service state
+if ! systemctl is-enabled --quiet service 2>/dev/null; then
+    run_cmd systemctl enable --quiet service
+fi
+```
+
+### Example: Error Validation
+
+```bash
+# Validation errors → stdout, then exit
+[[ -z $DEPLOYER_VAR ]] && echo "Error: DEPLOYER_VAR required" && exit 1
+```
+
+### Example: Error Runtime
+
+```bash
+# Runtime errors → stderr, then exit
+if ! run_cmd mkdir -p /var/www/app 2>&1; then
+    echo "Error: Failed to create directory" >&2
+    exit 1
+fi
+
+# Inline error check
+
+cd /path || exit
+
+# Using fail helper
+
+run_cmd chown deployer:deployer /path || fail "Failed to set ownership"
+```
+
+### Example: Action Message (Correct)
+
+```bash
+# CORRECT - Explicit paths/names/versions
+echo "→ Creating /var/www/app directory..."
+echo "→ Installing PHP 8.4..."
+echo "→ Configuring Nginx for example.com..."
+
+# Message INSIDE conditional block
+if ! command -v nginx >/dev/null 2>&1; then
+    echo "→ Installing Nginx..."
+    run_cmd apt-get install -y -q nginx
+fi
+```
+
+### Example: Action Message (Wrong)
+
+```bash
+# WRONG - Generic messages
+echo "→ Creating directory..."
+echo "→ Installing package..."
+```
+
+### Example: Package Installation
+
+```bash
+# Install packages (Ubuntu only)
+local packages=(software-properties-common curl zip unzip)
+
+apt_get_with_retry install -y -q "${packages[@]}"
+```
+
+### Example: Non-Interactive Apt
+
+```bash
+# Adding a repository key (non-interactive)
+curl -fsSL https://example.com/key.gpg | gpg --batch --yes --dearmor -o /etc/apt/keyrings/example.gpg
+```
+
+### Example: User Script
+
+```bash
+#
+# Execute user script if it exists
+#
+# Arguments:
+#   $1 - Script path
+#   $2 - Script description (for error messages)
+
+run_user_script() {
+    local script_path=$1
+    local script_desc=${2:-script}
+
+    if [[ ! -f $script_path ]]; then
+        return 0
+    fi
+
+    if [[ ! -x $script_path ]]; then
+        chmod +x "$script_path" || fail "Failed to make ${script_desc} executable"
+        run_as_deployer chmod +x "$script_path" > /dev/null 2>&1 || true
+    fi
+
+    echo "→ Running ${script_desc}..."
+
+    if ! run_as_deployer "$script_path"; then
+        fail "${script_desc} failed"
+    fi
+
+}
+
+# Usage
+
+run_user_script "${RELEASE_PATH}/.deployer/hooks/1-building.sh" "1-building.sh hook"
+```
+
+### Example: YAML Output Simple
+
+```bash
+# Simple success
+if ! cat > "$DEPLOYER_OUTPUT_FILE" <<EOF; then
+status: success
+EOF
+    echo "Error: Failed to write output file" >&2
+    exit 1
+fi
+```
+
+### Example: YAML Output Data
+
+```bash
+# With additional data
+if ! cat > "$DEPLOYER_OUTPUT_FILE" <<EOF; then
+status: success
+site_path: ${site_path}
+php_version: ${php_version}
+EOF
+    echo "Error: Failed to write output file" >&2
+    exit 1
+fi
+```
+
+### Example: Credential Generation
+
+```bash
+main() {
+    local db_user="deployer"
+    local db_pass
+    db_pass=$(openssl rand -base64 24)
+
+    # ... service installation ...
+
+    if ! cat > "$DEPLOYER_OUTPUT_FILE" <<EOF; then
+status: success
+mysql_user: ${db_user}
+mysql_pass: ${db_pass}
+EOF
+        echo "Error: Failed to write output file" >&2
+        exit 1
+    fi
+
+}
+```
+
+### Example: Logrotate Config
+
+```bash
+# Per-supervisor-program logrotate config
+local logrotate_file="${LOGROTATE_DIR}/supervisor-${domain}-${program}.conf"
+
+if ! run_cmd tee "$logrotate_file" > /dev/null <<EOF; then
+/var/log/supervisor/${domain}-${program}.log {
+    daily
+    rotate 5
+    maxage 30
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+}
+EOF
+    echo "Error: Failed to write ${logrotate_file}" >&2
+    exit 1
+fi
+```
+
+### Example: Log Directory
+
+```bash
+if [[ ! -d /var/log/myservice ]]; then
+    echo "→ Creating /var/log/myservice directory..."
+    run_cmd mkdir -p /var/log/myservice
+    run_cmd chown myservice:myservice /var/log/myservice
+fi
+```
+
+## Rules
+
+- ALWAYS check before acting (idempotency)
+- Validation errors → stdout; Runtime errors → stderr
+- Use `→` prefix for action messages with explicit paths/names/versions
+- Never manually inline helpers into playbooks
+- Include helper placeholder comment after header validation
+- Write YAML output at end of `main()`
+- Always wrap YAML write in error check
+- Document credential returns in playbook header
+- Create logrotate configs at resource creation time, not base installation
+- Remove logrotate configs when removing resources (orphan cleanup)

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.cursor/.agent-tools/
 .deployer/
 .experiments/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# DeployerPHP
+
+DeployerPHP is a Symfony Console Composer package (`loadinglucian/deployer-php`)
+for provisioning, installing, and deploying servers and sites.
+
+> **IMPORTANT**
+>
+> - All object creation goes through `Container` (except DTOs/Builders)
+> - DTOs are ALWAYS created via Builders, never directly with `new *DTO()`
+> - Services throw complete, user-facing exceptions; Commands display them
+>   without prefixes
+>
+> Keep this file lean and always-on. Put deep domain procedures in project
+> skills under `.agents/skills/`.
+
+## Context
+
+### Architecture
+
+Update and maintain this Architecture section when the system changes.
+
+```mermaid
+flowchart TD
+    bin/deployer --> Container --> SymfonyApp --> Commands
+    Commands --> Traits --> Services --> Repositories
+    Services --> Builders --> DTOs
+    Repositories --> Builders
+    Commands -.-> playbooks[playbooks/]
+```
+
+```text
+app/
+├── Builders/          # DTO factory classes (centralized instantiation)
+├── Console/           # Commands
+│   ├── Cloud/         # AWS/Cloudflare/DigitalOcean command domains
+│   ├── Cron/
+│   ├── Mariadb/
+│   ├── Memcached/
+│   ├── Nginx/
+│   ├── Php/
+│   ├── Postgresql/
+│   ├── Redis/
+│   ├── Scaffold/
+│   ├── Server/
+│   ├── Site/
+│   └── Supervisor/
+├── Services/          # Business logic and provider integrations
+├── Repositories/      # Inventory access
+├── DTOs/              # Immutable readonly data objects
+├── Traits/            # Shared command behavior
+├── Contracts/         # BaseCommand
+├── Enums/             # Domain enums (distribution, WWW mode, etc.)
+├── Exceptions/        # Custom exceptions
+├── Container.php      # DI auto-wiring
+└── SymfonyApp.php     # CLI registration
+playbooks/             # Remote bash scripts
+tests/bats/            # VM + cloud integration tests
+```
+
+| Layer        | Purpose                         | I/O         |
+| ------------ | ------------------------------- | ----------- |
+| Commands     | Orchestrate user interaction    | Yes         |
+| Traits       | Shared command operations       | Via Command |
+| Services     | Business logic, external APIs   | No          |
+| Repositories | Inventory CRUD                  | No          |
+| Builders     | Centralized DTO instantiation   | No          |
+| DTOs         | Immutable readonly data objects | No          |
+| playbooks/   | Remote server provisioning      | Via SSH     |
+
+### Key Runtime Contracts
+
+**Install credentials:**
+
+- `mariadb:install`, `postgresql:install`, and `redis:install` support
+  `--display-credentials` and `--save-credentials`.
+- BATS credential-auth checks for install commands run from server localhost
+  context via SSH.
+- `memcached:install` has no credential output flow.
+
+**Playbook/test contracts:**
+
+- Playbooks do not consume `DEPLOYER_DISTRO`; distro validation is centralized
+  in `ServersTrait::getServerInfo()` and cloud image selection.
+- VM distro/port mapping is centralized in `tests/bats/lib/vm-matrix.bash`.
+- Cloud test naming/cleanup contracts are centralized in
+  `tests/bats/lib/cloud-helpers.bash` and `tests/bats/lib/cloud-janitor.sh`.
+- Cloud tests use stable run-suffix naming (`r<suffix>` and `r<suffix>.v2`),
+  and do not create/validate `www.*` records.
+
+**Server info validation:**
+
+- `getServerInfo()` runs `server-info.sh` via SSH and validates Ubuntu,
+  version (LTS 24.04+), and permissions.
+- Skip info validation only for commands that do not depend on playbooks/server
+  state:
+    - `server:ssh`
+    - `server:run`
+    - `site:ssh`
+    - `site:dns:check`
+
+**Site WWW behavior:**
+
+- `site:create` auto-detects subdomains with `DomainOperationsTrait::isSubdomain()` and
+  forces `www_mode=none`.
+- For subdomains, only `--www-mode=none` is valid; other values are ignored
+  with a warning.
+- Site inventory persists `www_mode` and `has_www`; commands must use
+  `SiteDTO::$hasWww` instead of assuming `www.<domain>` exists.
+- Canonical WWW mode values are centralized in `Enums\WwwMode`.
+
+**DNS check behavior:**
+
+- `site:dns:check` wraps Google DNS lookups in `RetryService`.
+- It checks `www.<domain>` only when `SiteDTO::$hasWww` is true.
+
+## Skills
+
+Use these project-local skills for deep procedural guidance.
+
+| Domain          | Skill                            | Path                                                     |
+| --------------- | -------------------------------- | -------------------------------------------------------- |
+| Commands/Traits | `deployerphp-command-authoring`  | `.agents/skills/deployerphp-command-authoring/SKILL.md`  |
+| Playbooks       | `deployerphp-playbook-authoring` | `.agents/skills/deployerphp-playbook-authoring/SKILL.md` |
+| BATS            | `deployerphp-bats-testing`       | `.agents/skills/deployerphp-bats-testing/SKILL.md`       |
+| GitHub Actions  | `deployerphp-gha-ci`             | `.agents/skills/deployerphp-gha-ci/SKILL.md`             |
+| Documentation   | `deployerphp-docs-policy`        | `.agents/skills/deployerphp-docs-policy/SKILL.md`        |
+
+### Skill Loading Rule
+
+- If a task touches one of the domains above, load the matching skill first.
+- Read only the needed reference files from that skill.
+- Do not duplicate large rule blocks from skills back into `AGENTS.md`.
+
+## Standards
+
+- Use `$container->build(ClassName::class)` for object creation (except
+  DTOs/Builders).
+- Instantiate DTOs through builders (`::new()`, `::from()`, `::fromStorage()`).
+- Services throw complete user-facing exceptions with context.
+- Commands display exception messages directly (no prefixed wrappers).
+- Preserve exception chains with `previous: $e`.
+
+## Constraints
+
+- Never instantiate DTOs directly with `new *DTO()`.
+- Never bypass `Container` for object creation (except DTOs/Builders).
+- Never add prefixes when printing service exception messages in commands.
+- Never wrap exceptions without `previous: $e`.


### PR DESCRIPTION
## Summary
- add repo-local AGENTS.md guidance for DeployerPHP
- vendor project skills under .agents/skills so referenced paths exist after checkout
- fix migrated playbook and command-authoring guidance issues from review

## Verification
- git diff --cached --check
- git diff --check
- rg -n '\\[\\[-z|docs-agent|<<- EOF' AGENTS.md .agents/skills || true