### PR TITLE
docs(changelog): add entry for v1.0.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.0.5] - 2026-04-30
+
+### Added
+
+- add project agent skills for command, playbook, BATS, GitHub Actions, and documentation workflows (#375)
+
+### Fixed
+
+- fix markdown lint configuration and documentation lint issues (#376)
+
+### Changed
+
+- bump AWS SDK, Laravel Prompts, Symfony, Guzzle PSR-7, phpseclib, Pint, PHPStan, Rector, and related PHP dependencies (#366)
+- bump phpseclib/phpseclib from 3.0.49 to 3.0.51
+- bump markdownlint-cli2 from 0.21.0 to 0.22.0
+
 ## [1.0.4] - 2026-02-25
 
 ### Added


### PR DESCRIPTION
## Summary
- add the v1.0.5 changelog entry
- summarize agent skill docs, markdown lint fixes, and dependency updates since v1.0.4

## Verification
- bun run lint:md